### PR TITLE
Add support for TxnDel

### DIFF
--- a/lib/to_qbxml/to_qbxml.rb
+++ b/lib/to_qbxml/to_qbxml.rb
@@ -107,7 +107,7 @@ class ToQbxml
 
   def boilerplate(type, opts = {})
     head = boilerplate_header(type, opts[:action] || 'add')
-    body_hash = opts[:action] == :query ? @hash : { head => @hash }
+    body_hash = [:query, :del].include?(opts[:action]) ? @hash : { head => @hash }
     {  :qbxml_msgs_rq =>
        [
          {


### PR DESCRIPTION
https://developer.intuit.com/app/developer/qbdesktop/docs/api-reference/qbdesktop/txndel

Action with type `:del` does not leave out the `boilerplate_header`. This change will cause the boilerplate to leave to out the header if the action is `:del` in accordance with the specs for TxnDel (1.1).